### PR TITLE
(fix): Fix cancelOperation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # \<yolo-auth\>
 
 [![Published on webcomponents.org](https://img.shields.io/badge/webcomponents.org-published-blue.svg)](https://www.webcomponents.org/element/hemantjadon/yolo-auth)
+[![Build Status](https://travis-ci.org/hemantjadon/yolo-auth.svg?branch=master)](https://travis-ci.org/hemantjadon/yolo-auth)
 
 `yolo-auth` is wrapper around Google OneTap YOLO implementation. It notifies the successful authentication and provides user information and handles Google YOLO implementaion.
 

--- a/yolo-auth.html
+++ b/yolo-auth.html
@@ -177,9 +177,15 @@
        * The promise which resolves when credentials selector is closed, rejects if there is error
        */
       cancelOperation() {
-        if (window.googleyolo) {
-          return window.googleyolo.cancelLastOperation();
-        }
+        return new Promise((resolve, reject) => {
+          if (window.googleyolo) {
+            window.googleyolo.cancelLastOperation()
+              .then(resp => resolve({ ok: true }))
+              .catch(error => reject(error));
+          } else {
+            resolve({ ok: true });
+          }
+        });
       }
     }
 


### PR DESCRIPTION
Now returns a promise which immediately resolves when googleyolo object is not available in the window, this assumes that the cancel opertaion action should only take place when there is googleyolo object in window,